### PR TITLE
Return a proper response if a transaction can't be paid (fixes #477)

### DIFF
--- a/silver/templates/transactions/complete_payment.html
+++ b/silver/templates/transactions/complete_payment.html
@@ -1,35 +1,62 @@
 {% load staticfiles %}
 <html>
-<head>
-    <title>
-      Payment completed for {{ document.kind }} {{ document.series }}-{{ document.number }}
-    </title>
-    <style type="text/css">
-        @page {
-            size: a4;
-            margin: 2cm;
-        }
-    </style>
-    <link rel="stylesheet" type="text/css" href="{% static 'css/skeleton.css' %}">
+    <head>
+        <title>
+          Payment completed for {{ document.kind }} {{ document.series }}-{{ document.number }}
+        </title>
 
-    {% block extrahead %}
-    {% endblock %}
+        <style type="text/css">
+            @page {
+                size: a4;
+                margin: 2cm;
+            }
+        </style>
+        <link rel="stylesheet" type="text/css" href="{% static 'css/skeleton.css' %}">
 
-</head>
-<body>
-    <div class="container">
-      {% block content%}
-        <h2>
-          {% if transaction.state == transaction.States.Failed %}
-            Payment failed for
-          {% elif transaction.state == transaction.States.Pending %}
-              Payment pending for
-          {% else %}
-            Payment succeded for
-          {% endif %}
+        {% block extrahead %}
+        {% endblock %}
 
-          {{ document.kind }} {{ document.series }}-{{ document.number }}
-        </h2>
-      {% endblock%}
-    </div>
-</body>
+    </head>
+
+    <body>
+        <div class="container">
+            {% block content%}
+
+                {% if not expired %}
+
+                    {% block transaction_state %}
+                        <div>
+                            <h2>
+                              {% if transaction.state == transaction.States.Failed %}
+                                Payment failed for
+                              {% elif transaction.state == transaction.States.Pending %}
+                                Payment pending for
+                              {% elif transaction.state == transaction.States.Initial %}
+                                Payment is still initializing for
+                              {% else %}
+                                Payment succeded for
+                              {% endif %}
+                            </h2>
+                        </div>
+                    {% endblock %}
+
+                {% else %}
+
+                    {% block transaction_expired %}
+                        <h2>
+                            Transaction expired for
+                        </h2>
+                    {% endblock %}
+
+                {% endif %}
+
+                {% block document %}
+                    <div>
+                        <h3>{{ document.kind }} {{ document.series }}-{{ document.number }}</h3>
+                    </div>
+                {% endblock %}
+
+            {% endblock%}
+        </div>
+    </body>
+</html>

--- a/silver/templates/transactions/complete_payment.html
+++ b/silver/templates/transactions/complete_payment.html
@@ -21,41 +21,27 @@
     <body>
         <div class="container">
             {% block content%}
-
-                {% if not expired %}
-
-                    {% block transaction_state %}
-                        <div>
-                            <h2>
-                              {% if transaction.state == transaction.States.Failed %}
-                                Payment failed for
-                              {% elif transaction.state == transaction.States.Pending %}
-                                Payment pending for
-                              {% elif transaction.state == transaction.States.Initial %}
-                                Payment is still initializing for
-                              {% else %}
-                                Payment succeded for
-                              {% endif %}
-                            </h2>
-                        </div>
-                    {% endblock %}
-
-                {% else %}
-
-                    {% block transaction_expired %}
+                {% block transaction_state %}
+                    <div>
                         <h2>
-                            Transaction expired for
+                          {% if transaction.state == transaction.States.Failed %}
+                            Payment failed for
+                          {% elif transaction.state == transaction.States.Pending %}
+                            Payment pending for
+                          {% elif transaction.state == transaction.States.Initial %}
+                            Payment is still initializing for
+                          {% else %}
+                            Payment succeded for
+                          {% endif %}
                         </h2>
-                    {% endblock %}
-
-                {% endif %}
+                    </div>
+                {% endblock %}
 
                 {% block document %}
                     <div>
                         <h3>{{ document.kind }} {{ document.series }}-{{ document.number }}</h3>
                     </div>
                 {% endblock %}
-
             {% endblock%}
         </div>
     </body>

--- a/silver/templates/transactions/expired_payment.html
+++ b/silver/templates/transactions/expired_payment.html
@@ -21,9 +21,7 @@
     <body>
         <div class="container">
             {% block content%}
-                {% block expired %}
-                    <h2>Transaction expired for</h2>
-                {% endblock %}
+                <h2>Transaction expired for</h2>
 
                 {% block document %}
                     <div>

--- a/silver/templates/transactions/expired_payment.html
+++ b/silver/templates/transactions/expired_payment.html
@@ -1,0 +1,36 @@
+{% load staticfiles %}
+<html>
+    <head>
+        <title>
+          Payment not found for {{ document.kind }} {{ document.series }}-{{ document.number }}
+        </title>
+
+        <style type="text/css">
+            @page {
+                size: a4;
+                margin: 2cm;
+            }
+        </style>
+        <link rel="stylesheet" type="text/css" href="{% static 'css/skeleton.css' %}">
+
+        {% block extrahead %}
+        {% endblock %}
+
+    </head>
+
+    <body>
+        <div class="container">
+            {% block content%}
+                {% block expired %}
+                    <h2>Transaction expired for</h2>
+                {% endblock %}
+
+                {% block document %}
+                    <div>
+                        <h3>{{ document.kind }} {{ document.series }}-{{ document.number }}</h3>
+                    </div>
+                {% endblock %}
+            {% endblock%}
+        </div>
+    </body>
+</html>

--- a/silver/tests/spec/test_payments.py
+++ b/silver/tests/spec/test_payments.py
@@ -41,7 +41,12 @@ class TestPaymentUrls(APITestCase):
             url = get_payment_url(transaction, None)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content,
+                         render_to_string('transactions/expired_payment.html', {
+                             'document': transaction.document,
+                         }))
 
     def test_pay_transaction_view_invalid_state(self):
         transaction = TransactionFactory.create(state=Transaction.States.Settled)
@@ -50,7 +55,6 @@ class TestPaymentUrls(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content,
                          render_to_string('transactions/complete_payment.html', {
-                             'expired': False,
                              'transaction': transaction,
                              'document': transaction.document,
                          }))
@@ -61,7 +65,11 @@ class TestPaymentUrls(APITestCase):
                                                 valid_until=last_year)
 
         response = self.client.get(get_payment_url(transaction, None))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content,
+                         render_to_string('transactions/expired_payment.html', {
+                             'document': transaction.document,
+                         }))
 
     def test_pay_transaction_view_missing_view(self):
         last_year = timezone.now() - timedelta(days=365)
@@ -74,7 +82,12 @@ class TestPaymentUrls(APITestCase):
         with patch('silver.tests.fixtures.ManualProcessor.get_view',
                    new=get_view):
             response = self.client.get(get_payment_url(transaction, None))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content,
+                         render_to_string('transactions/expired_payment.html', {
+                             'document': transaction.document,
+                         }))
 
     def test_pay_transaction_not_implemented_get_call(self):
         last_year = timezone.now() - timedelta(days=365)
@@ -88,7 +101,11 @@ class TestPaymentUrls(APITestCase):
                    new=get_view):
             response = self.client.get(get_payment_url(transaction, None))
 
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content,
+                         render_to_string('transactions/expired_payment.html', {
+                             'document': transaction.document,
+                         }))
 
     def test_complete_payment_view_with_return_url(self):
         transaction = TransactionFactory.create(state=Transaction.States.Settled)

--- a/silver/views.py
+++ b/silver/views.py
@@ -65,12 +65,14 @@ def complete_payment_view(request, transaction, expired=None):
 @get_transaction_from_token
 def pay_transaction_view(request, transaction, expired=None):
     if expired:
-        raise Http404
+        return render(request, 'transactions/expired_payment.html',
+                      {
+                          'document': transaction.document,
+                      })
 
     if transaction.state != Transaction.States.Initial:
         return render(request, 'transactions/complete_payment.html',
                       {
-                          'expired': expired,
                           'transaction': transaction,
                           'document': transaction.document,
                       })
@@ -79,7 +81,10 @@ def pay_transaction_view(request, transaction, expired=None):
 
     view = payment_processor.get_view(transaction, request)
     if not view or not transaction.can_be_consumed:
-        raise Http404
+        return render(request, 'transactions/expired_payment.html',
+                      {
+                          'document': transaction.document,
+                      })
 
     transaction.last_access = timezone.now()
     transaction.save()


### PR DESCRIPTION
Render `expired_payment.html` template in case a transaction can't be paid.