### PR TITLE
Pdf generation task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 full-test: test
 
 test:
-	python manage.py test -v2
+	DJANGO_SETTINGS_MODULE=settings pytest -vv
 
 run:
 	echo "TBA"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -26,4 +26,3 @@ cryptography==1.7.1
 sqlparse==0.2.2
 django-autocomplete-light==3.2.1
 celery[redis]
-redlock-py==1.0.8

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,3 +25,5 @@ html5lib==0.999
 cryptography==1.7.1
 sqlparse==0.2.2
 django-autocomplete-light==3.2.1
+celery[redis]
+redlock-py==1.0.8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,8 +5,8 @@ flake8==2.4.1
 freezegun==0.3.8
 coverage==3.7.1
 django-coverage==1.2.4
-pytest==2.7.2
-pytest-django>=2.8.0
+pytest==3.0.7
+pytest-django==2.9.1
 factory-boy==2.5.2
 simplejson==3.8.0
 pep8==1.7.0

--- a/settings.py
+++ b/settings.py
@@ -161,6 +161,16 @@ PAYMENT_PROCESSORS = {
 }
 
 PAYMENT_METHOD_SECRET = b'YOUR_FERNET_KEY_HERE'  # Fernet.generate_key()
+
+CELERY_BROKER_URL = 'redis://localhost:6379/'
+CELERY_BEAT_SCHEDULE = {
+    'generate-pdfs': {
+        'task': 'silver.tasks.generate_pdfs',
+        'schedule': datetime.timedelta(seconds=5)
+    },
+}
+LOCK_MANAGER_CONNECTION = {'host': 'localhost', 'port': 6379, 'db': 1}
+
 try:
     from settings_local import *
 except ImportError:

--- a/settings.py
+++ b/settings.py
@@ -171,6 +171,8 @@ CELERY_BEAT_SCHEDULE = {
 }
 LOCK_MANAGER_CONNECTION = {'host': 'localhost', 'port': 6379, 'db': 1}
 
+PDF_GENERATION_TIME_LIMIT = 60
+
 try:
     from settings_local import *
 except ImportError:

--- a/silver/api/serializers.py
+++ b/silver/api/serializers.py
@@ -348,7 +348,7 @@ class PaymentProcessorUrl(serializers.HyperlinkedRelatedField):
 
 class PDFUrl(serializers.HyperlinkedRelatedField):
     def get_url(self, obj, view_name, request, format):
-        return request.build_absolute_uri(obj.pdf.url) if obj.pdf else None
+        return request.build_absolute_uri(obj.pdf.url) if (obj.pdf and obj.pdf.url) else None
 
 
 class PaymentMethodUrl(serializers.HyperlinkedRelatedField):

--- a/silver/api/views.py
+++ b/silver/api/views.py
@@ -619,7 +619,6 @@ class InvoiceStateHandler(APIView):
             issue_date = request.data.get('issue_date', None)
             due_date = request.data.get('due_date', None)
             invoice.issue(issue_date, due_date)
-            invoice.save()
         elif state == Invoice.STATES.PAID:
             if invoice.state != Invoice.STATES.ISSUED:
                 msg = "An invoice can be paid only if it is in issued state."
@@ -628,7 +627,6 @@ class InvoiceStateHandler(APIView):
 
             paid_date = request.data.get('paid_date', None)
             invoice.pay(paid_date)
-            invoice.save()
         elif state == Invoice.STATES.CANCELED:
             if invoice.state != Invoice.STATES.ISSUED:
                 msg = "An invoice can be canceled only if it is in issued " \
@@ -638,7 +636,6 @@ class InvoiceStateHandler(APIView):
 
             cancel_date = request.data.get('cancel_date', None)
             invoice.cancel(cancel_date)
-            invoice.save()
         elif not state:
             msg = "You have to provide a value for the state field."
             return Response({"detail": msg}, status=status.HTTP_403_FORBIDDEN)
@@ -757,7 +754,6 @@ class ProformaStateHandler(APIView):
             issue_date = request.data.get('issue_date', None)
             due_date = request.data.get('due_date', None)
             proforma.issue(issue_date, due_date)
-            proforma.save()
         elif state == Proforma.STATES.PAID:
             if proforma.state != Proforma.STATES.ISSUED:
                 msg = "A proforma can be paid only if it is in issued state."
@@ -766,7 +762,6 @@ class ProformaStateHandler(APIView):
 
             paid_date = request.data.get('paid_date', None)
             proforma.pay(paid_date)
-            proforma.save()
         elif state == Proforma.STATES.CANCELED:
             if proforma.state != Proforma.STATES.ISSUED:
                 msg = "A proforma can be canceled only if it is in issued " \
@@ -776,7 +771,6 @@ class ProformaStateHandler(APIView):
 
             cancel_date = request.data.get('cancel_date', None)
             proforma.cancel(cancel_date)
-            proforma.save()
         elif not state:
             msg = "You have to provide a value for the state field."
             return Response({"detail": msg}, status=status.HTTP_403_FORBIDDEN)

--- a/silver/documents_generator.py
+++ b/silver/documents_generator.py
@@ -149,7 +149,6 @@ class DocumentsGenerator(object):
         for provider, document in cached_documents.iteritems():
             if provider.default_document_state == Provider.DEFAULT_DOC_STATE.ISSUED:
                 document.issue()
-                document.save()
 
     def _generate_for_user_without_consolidated_billing(self, customer,
                                                         billing_date,
@@ -197,7 +196,6 @@ class DocumentsGenerator(object):
 
             if provider.default_document_state == Provider.DEFAULT_DOC_STATE.ISSUED:
                 document.issue()
-                document.save()
 
     def _generate_for_single_subscription(self, subscription=None,
                                           billing_date=None):
@@ -228,7 +226,6 @@ class DocumentsGenerator(object):
 
         if provider.default_document_state == Provider.DEFAULT_DOC_STATE.ISSUED:
             document.issue()
-            document.save()
 
     def _create_document(self, provider, customer, subscription, billing_date):
         DocumentModel = (Proforma if provider.flow == provider.FLOWS.PROFORMA

--- a/silver/migrations/0036_auto_20170514_1627.py
+++ b/silver/migrations/0036_auto_20170514_1627.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import uuid
+
 from django.db import migrations, models
-from django.db.models import Q
 
 import silver.models.documents.pdf
 from silver.models import BillingDocumentBase
@@ -21,8 +22,8 @@ class Migration(migrations.Migration):
         Proforma = apps.get_model('silver', 'Proforma')
         PDF = apps.get_model('silver', 'PDF')
 
-        for invoice in Invoice.objects.using(db_alias).filter(
-            ~Q(state=BillingDocumentBase.STATES.DRAFT)
+        for invoice in Invoice.objects.using(db_alias).exclude(
+            state=BillingDocumentBase.STATES.DRAFT
         ):
             pdf_object = PDF.objects.using(db_alias).create(
                 upload_path=invoice.get_pdf_upload_path()
@@ -41,6 +42,7 @@ class Migration(migrations.Migration):
             name='PDF',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('uuid', models.UUIDField(default=uuid.uuid4, unique=True)),
                 ('pdf_file', models.FileField(upload_to=silver.models.documents.pdf.get_upload_path, null=True, editable=False, blank=True)),
                 ('dirty', models.BooleanField(default=False)),
                 ('upload_path', models.TextField(null=True, blank=True)),

--- a/silver/migrations/0036_auto_20170514_1627.py
+++ b/silver/migrations/0036_auto_20170514_1627.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.db.models import Q
+
+import silver.models.documents.pdf
+from silver.models import BillingDocumentBase
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('silver', '0035_auto_20170206_0941'),
+    ]
+
+    def move_pdf_from_documents_to_model(apps, schema_editor):
+        db_alias = schema_editor.connection.alias
+
+        Invoice = apps.get_model('silver', 'Invoice')
+        Proforma = apps.get_model('silver', 'Proforma')
+        PDF = apps.get_model('silver', 'PDF')
+
+        for invoice in Invoice.objects.using(db_alias).filter(
+            ~Q(state=BillingDocumentBase.STATES.DRAFT)
+        ):
+            pdf_object = PDF.objects.using(db_alias).create(
+                upload_path=invoice.get_pdf_upload_path()
+            )
+            pdf_object.pdf_file = invoice.pdf
+            pdf_object.save(using=db_alias)
+
+            invoice.pdf = pdf_object
+            invoice.save(using=db_alias)
+
+    def move_pdf_from_model_to_documents(apps, schema_editor):
+        pass
+
+    operations = [
+        migrations.CreateModel(
+            name='PDF',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('pdf_file', models.FileField(upload_to=silver.models.documents.pdf.get_upload_path, null=True, editable=False, blank=True)),
+                ('dirty', models.BooleanField(default=False)),
+                ('upload_path', models.TextField(null=True, blank=True)),
+            ],
+        ),
+        migrations.RenameField(
+            model_name='invoice',
+            old_name='pdf',
+            new_name='pdf_old'
+        ),
+        migrations.RenameField(
+            model_name='proforma',
+            old_name='pdf',
+            new_name='pdf_old'
+        ),
+
+        migrations.AddField(
+            model_name='invoice',
+            name='pdf',
+            field=models.ForeignKey(to='silver.PDF', null=True),
+        ),
+        migrations.AddField(
+            model_name='proforma',
+            name='pdf',
+            field=models.ForeignKey(to='silver.PDF', null=True),
+        ),
+
+        migrations.RunPython(move_pdf_from_documents_to_model,
+                             move_pdf_from_model_to_documents),
+
+        migrations.RemoveField(
+            model_name='invoice',
+            name='pdf_old',
+        ),
+        migrations.RemoveField(
+            model_name='proforma',
+            name='pdf_old',
+        ),
+        migrations.RunSQL("""
+                DROP VIEW IF EXISTS silver_document;
+                CREATE VIEW silver_document AS SELECT
+                    'invoice' AS `kind`, id, series, number, issue_date, due_date,
+                    paid_date, cancel_date, state, provider_id, customer_id,
+                    proforma_id as related_document_id, archived_customer,
+                    archived_provider, sales_tax_percent, sales_tax_name, currency, pdf_id,
+                    transaction_currency
+                    FROM silver_invoice
+                UNION
+                SELECT
+                    'proforma' AS `kind`, id, series, number, issue_date, due_date,
+                    paid_date, cancel_date, state, provider_id, customer_id,
+                    NULL as related_document_id, archived_customer,
+                    archived_provider, sales_tax_percent, sales_tax_name, currency, pdf_id,
+                    transaction_currency
+                    FROM silver_proforma WHERE invoice_id is NULL
+        """),
+    ]

--- a/silver/models/documents/__init__.py
+++ b/silver/models/documents/__init__.py
@@ -17,3 +17,4 @@ from .base import BillingDocumentBase
 from .entries import DocumentEntry
 from .invoice import Invoice
 from .proforma import Proforma
+from .pdf import PDF

--- a/silver/models/documents/base.py
+++ b/silver/models/documents/base.py
@@ -169,7 +169,7 @@ class BillingDocumentBase(models.Model):
         super(BillingDocumentBase, self).__init__(*args, **kwargs)
         self._last_state = self.state
 
-    def set_pdf_for_generation(self):
+    def mark_for_generation(self):
         self.pdf.dirty = True
         self.pdf.save()
 
@@ -589,4 +589,4 @@ def post_document_save(sender, instance, created=False, **kwargs):
                 create_transaction_for_document(document)
 
         # Generate a PDF
-        document.set_pdf_for_generation()
+        document.mark_for_generation()

--- a/silver/models/documents/document.py
+++ b/silver/models/documents/document.py
@@ -51,8 +51,7 @@ class Document(models.Model):
     currency = models.CharField(max_length=4)
     transaction_currency = models.CharField(max_length=4)
     state = models.CharField(max_length=10)
-    pdf = models.FileField(null=True, blank=True, editable=False,
-                           storage=_storage, upload_to=documents_pdf_path)
+    pdf = models.ForeignKey('PDF', null=True)
 
     class Meta:
         managed = False

--- a/silver/models/documents/invoice.py
+++ b/silver/models/documents/invoice.py
@@ -46,31 +46,6 @@ class Invoice(BillingDocumentBase):
 
         super(Invoice, self)._issue(issue_date, due_date)
 
-    @transition(field='state', source=BillingDocumentBase.STATES.ISSUED,
-                target=BillingDocumentBase.STATES.PAID)
-    def pay(self, paid_date=None, affect_related_document=True):
-        super(Invoice, self)._pay(paid_date)
-
-        if self.proforma and affect_related_document:
-            try:
-                self.proforma.pay(paid_date=paid_date,
-                                  affect_related_document=False)
-                self.proforma.save()
-            except TransitionNotAllowed:
-                # the related proforma is already paid
-                # other inconsistencies should've been fixed before
-                pass
-
-    @transition(field='state', source=BillingDocumentBase.STATES.ISSUED,
-                target=BillingDocumentBase.STATES.CANCELED)
-    def cancel(self, cancel_date=None, affect_related_document=True):
-        super(Invoice, self)._cancel(cancel_date)
-
-        if self.proforma and affect_related_document:
-            self.proforma.cancel(cancel_date=cancel_date,
-                                 affect_related_document=False)
-            self.proforma.save()
-
     @property
     def _starting_number(self):
         return self.provider.invoice_starting_number

--- a/silver/models/documents/pdf.py
+++ b/silver/models/documents/pdf.py
@@ -1,0 +1,55 @@
+from django_xhtml2pdf.utils import generate_pdf_template_object
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.db.models import Model, BooleanField, FileField, TextField
+from django.http import HttpResponse
+from django.utils.module_loading import import_string
+
+
+def get_storage():
+    storage_settings = getattr(settings, 'SILVER_DOCUMENT_STORAGE', None)
+    if not storage_settings:
+        return
+
+    storage_class = import_string(storage_settings[0])
+    return storage_class(*storage_settings[1], **storage_settings[2])
+
+
+def get_upload_path(instance, filename):
+    return instance.upload_path
+
+
+class PDF(Model):
+    pdf_file = FileField(null=True, blank=True, editable=False,
+                         storage=get_storage(), upload_to=get_upload_path)
+    dirty = BooleanField(default=False)
+    upload_path = TextField(null=True, blank=True)
+
+    @property
+    def url(self):
+        return self.pdf_file.url if self.pdf_file else None
+
+    def generate(self, template, context, upload=True):
+        pdf_file_object = HttpResponse(content_type='application/pdf')
+
+        generate_pdf_template_object(template, pdf_file_object, context)
+
+        if not pdf_file_object:
+            return
+
+        if upload:
+            self.upload(pdf_file_object=pdf_file_object, filename=context['filename'])
+
+        return pdf_file_object
+
+    def upload(self, pdf_file_object, filename):
+        # the PDF's upload_path attribute needs to be set before calling this method
+
+        pdf_content = ContentFile(pdf_file_object)
+
+        # delete old pdf version
+        if self.pdf_file:
+            self.pdf_file.delete()
+
+        self.pdf_file.save(filename, pdf_content, True)

--- a/silver/models/documents/pdf.py
+++ b/silver/models/documents/pdf.py
@@ -1,8 +1,10 @@
+import uuid
+
 from django_xhtml2pdf.utils import generate_pdf_template_object
 
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.db.models import Model, BooleanField, FileField, TextField
+from django.db.models import Model, BooleanField, FileField, TextField, UUIDField
 from django.http import HttpResponse
 from django.utils.module_loading import import_string
 
@@ -21,6 +23,7 @@ def get_upload_path(instance, filename):
 
 
 class PDF(Model):
+    uuid = UUIDField(default=uuid.uuid4, unique=True)
     pdf_file = FileField(null=True, blank=True, editable=False,
                          storage=get_storage(), upload_to=get_upload_path)
     dirty = BooleanField(default=False)

--- a/silver/tasks.py
+++ b/silver/tasks.py
@@ -1,8 +1,12 @@
 from itertools import chain
 
+from celery import group
+from django.conf import settings
+from redis.exceptions import LockError
+
 from silver.models import Invoice, Proforma
 from silver.vendors.celery_app import task
-from silver.vendors.redis_server import lock_manager
+from silver.vendors.redis_server import redis
 
 
 @task()
@@ -15,24 +19,24 @@ def generate_pdf(document_id, document_type):
     document.generate_pdf()
 
 
-@task()
-def generate_pdfs():
-    lock = lock_manager.lock('generate_pdfs', 60000)
-    if not lock:
-        return
+PDF_GENERATION_TIME_LIMIT = getattr(settings, 'PDF_GENERATION_TIME_LIMIT', 60)
 
-    tasks = []
+
+@task(time_limit=PDF_GENERATION_TIME_LIMIT, ignore_result=True)
+def generate_pdfs():
+    lock = redis.lock('reconcile_new_domains_without_cert', timeout=PDF_GENERATION_TIME_LIMIT)
+
+    if not lock.acquire(blocking=False):
+        return
 
     dirty_documents = chain(Invoice.objects.filter(pdf__dirty=True),
                             Proforma.objects.filter(pdf__dirty=True))
 
-    async_results = list([
-        tasks.append(generate_pdf.delay(document.id, document.kind))
-        for document in dirty_documents
-    ])
+    # Generate PDFs in parallel
+    group(generate_pdf.s(document.id, document.kind)
+          for document in dirty_documents)()
 
-    for async_result in async_results:
-        if async_result:
-            async_result.get()
-
-    lock_manager.unlock(lock)
+    try:
+        lock.release()
+    except LockError:
+        pass

--- a/silver/tasks.py
+++ b/silver/tasks.py
@@ -1,0 +1,38 @@
+from itertools import chain
+
+from silver.models import Invoice, Proforma
+from silver.vendors.celery_app import task
+from silver.vendors.redis_server import lock_manager
+
+
+@task()
+def generate_pdf(document_id, document_type):
+    if document_type == 'Invoice':
+        document = Invoice.objects.get(id=document_id)
+    else:
+        document = Proforma.objects.get(id=document_id)
+
+    document.generate_pdf()
+
+
+@task()
+def generate_pdfs():
+    lock = lock_manager.lock('generate_pdfs', 60000)
+    if not lock:
+        return
+
+    tasks = []
+
+    dirty_documents = chain(Invoice.objects.filter(pdf__dirty=True),
+                            Proforma.objects.filter(pdf__dirty=True))
+
+    async_results = list([
+        tasks.append(generate_pdf.delay(document.id, document.kind))
+        for document in dirty_documents
+    ])
+
+    for async_result in async_results:
+        if async_result:
+            async_result.get()
+
+    lock_manager.unlock(lock)

--- a/silver/tests/factories.py
+++ b/silver/tests/factories.py
@@ -170,6 +170,10 @@ class InvoiceFactory(factory.django.DjangoModelFactory):
     currency = 'RON'
     transaction_currency = 'RON'
     transaction_xe_rate = Decimal(1)
+    state = Invoice.STATES.DRAFT
+    issue_date = factory.LazyAttribute(
+        lambda invoice: timezone.now().date() if invoice.state == Invoice.STATES.ISSUED else None
+    )
 
     @factory.post_generation
     def invoice_entries(self, create, extracted, **kwargs):
@@ -192,6 +196,10 @@ class ProformaFactory(factory.django.DjangoModelFactory):
     currency = 'RON'
     transaction_currency = 'RON'
     transaction_xe_rate = Decimal(1)
+    state = Proforma.STATES.DRAFT
+    issue_date = factory.LazyAttribute(
+        lambda proforma: timezone.now().date() if proforma.state == Proforma.STATES.ISSUED else None
+    )
 
     @factory.post_generation
     def subscriptions(self, create, extracted, **kwargs):

--- a/silver/tests/integration/test_documents_transactions.py
+++ b/silver/tests/integration/test_documents_transactions.py
@@ -106,16 +106,13 @@ class TestDocumentsTransactions(TestCase):
             document.
         """
         invoice = InvoiceFactory.create()
-        invoice.issue()
+        invoice.issue()  # this creates a Transaction
         customer = invoice.customer
         payment_method = PaymentMethodFactory.create(
             payment_processor=triggered_processor, customer=customer,
             canceled=False,
             verified=True,
         )
-
-        transaction = TransactionFactory.create(invoice=invoice,
-                                                payment_method=payment_method)
 
         mock_execute = MagicMock()
         with patch.multiple(TriggeredProcessor, execute_transaction=mock_execute):
@@ -133,7 +130,6 @@ class TestDocumentsTransactions(TestCase):
                 payment_method=payment_method, invoice=invoice,
             )
             self.assertEqual(len(transactions), 1)
-            self.assertEqual(transactions[0], transaction)
 
             self.assertEqual(mock_execute.call_count, 0)
 
@@ -148,7 +144,6 @@ class TestDocumentsTransactions(TestCase):
         )
 
         proforma.issue()
-        proforma.save()
 
         self.assertEqual(len(Transaction.objects.filter(proforma=proforma)),
                          1)
@@ -171,10 +166,7 @@ class TestDocumentsTransactions(TestCase):
         )
 
         proforma.issue()
-        proforma.save()
-
         proforma.pay()
-        proforma.save()
 
         invoice = proforma.invoice
 
@@ -194,7 +186,6 @@ class TestDocumentsTransactions(TestCase):
         )
 
         proforma.issue()
-        proforma.save()
 
         transaction = proforma.transactions[0]
         # here transaction.proforma is the same object as the proforma from the

--- a/silver/tests/spec/test_documents.py
+++ b/silver/tests/spec/test_documents.py
@@ -84,7 +84,8 @@ class TestDocumentEndpoints(APITestCase):
             u'transaction_currency': document.transaction_currency,
             u'state': document.state,
             u'total': document.total,
-            u'pdf_url': (u'http://testserver%s' % document.pdf.url) if document.pdf else None,
+            u'pdf_url': (u'http://testserver%s' % document.pdf.url) if (document.pdf and
+                                                                        document.pdf.url) else None,
             u'transactions': transactions,
             u'total_in_transaction_currency': document.total_in_transaction_currency
         }

--- a/silver/tests/spec/test_invoice.py
+++ b/silver/tests/spec/test_invoice.py
@@ -182,7 +182,7 @@ class TestInvoiceEndpoints(APITestCase):
                 "archived_provider": {},
                 "archived_customer": {},
                 "due_date": None,
-                "issue_date": None,
+                "issue_date": str(invoice.issue_date),
                 "paid_date": None,
                 "cancel_date": None,
                 "sales_tax_name": "VAT",
@@ -195,7 +195,7 @@ class TestInvoiceEndpoints(APITestCase):
                 "state": "issued",
                 "proforma": "http://testserver/proformas/%s/" % invoice.proforma.pk,
                 "invoice_entries": [],
-                "pdf_url": None,
+                "pdf_url": invoice.pdf.url,
                 "total": Decimal('0.00')
             }
             for field in expected_response:
@@ -347,7 +347,6 @@ class TestInvoiceEndpoints(APITestCase):
     def test_add_invoice_entry_in_issued_state(self):
         invoice = InvoiceFactory.create()
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-entry-create', kwargs={'document_pk': invoice.pk})
         entry_data = {
@@ -371,7 +370,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create()
         invoice.issue()
         invoice.cancel()
-        invoice.save()
 
         url = reverse('invoice-entry-create', kwargs={'document_pk': invoice.pk})
         entry_data = {
@@ -395,7 +393,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create()
         invoice.issue()
         invoice.pay()
-        invoice.save()
 
         url = reverse('invoice-entry-create', kwargs={'document_pk': invoice.pk})
         entry_data = {
@@ -418,7 +415,6 @@ class TestInvoiceEndpoints(APITestCase):
     def test_edit_invoice_in_issued_state(self):
         invoice = InvoiceFactory.create()
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-detail', kwargs={'pk': invoice.pk})
         data = {"description": "New Page views"}
@@ -433,7 +429,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create()
         invoice.issue()
         invoice.cancel()
-        invoice.save()
 
         url = reverse('invoice-detail', kwargs={'pk': invoice.pk})
         data = {"description": "New Page views"}
@@ -448,7 +443,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create()
         invoice.issue()
         invoice.pay()
-        invoice.save()
 
         url = reverse('invoice-detail', kwargs={'pk': invoice.pk})
         data = {"description": "New Page views"}
@@ -537,7 +531,6 @@ class TestInvoiceEndpoints(APITestCase):
         customer = CustomerFactory.create()
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'issued'}
@@ -554,7 +547,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
         invoice.pay()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'issued'}
@@ -570,7 +562,6 @@ class TestInvoiceEndpoints(APITestCase):
         customer = CustomerFactory.create()
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'paid'}
@@ -594,7 +585,6 @@ class TestInvoiceEndpoints(APITestCase):
         customer = CustomerFactory.create()
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {
@@ -636,7 +626,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
         invoice.pay()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'paid'}
@@ -652,7 +641,6 @@ class TestInvoiceEndpoints(APITestCase):
         customer = CustomerFactory.create()
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'canceled'}
@@ -676,7 +664,6 @@ class TestInvoiceEndpoints(APITestCase):
         customer = CustomerFactory.create()
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {
@@ -721,7 +708,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
         invoice.cancel()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'canceled'}
@@ -740,7 +726,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
         invoice.pay()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'canceled'}
@@ -772,7 +757,6 @@ class TestInvoiceEndpoints(APITestCase):
         customer = CustomerFactory.create()
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'illegal-state'}
@@ -789,7 +773,6 @@ class TestInvoiceEndpoints(APITestCase):
         invoice = InvoiceFactory.create(provider=provider, customer=customer)
         invoice.issue()
         invoice.pay()
-        invoice.save()
 
         url = reverse('invoice-state', kwargs={'pk': invoice.pk})
         data = {'state': 'illegal-state'}

--- a/silver/tests/spec/test_proforma.py
+++ b/silver/tests/spec/test_proforma.py
@@ -291,7 +291,6 @@ class TestProformaEndpoints(APITestCase):
     def test_add_proforma_entry_in_issued_state(self):
         proforma = ProformaFactory.create()
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-entry-create', kwargs={'document_pk': proforma.pk})
         entry_data = {
@@ -315,7 +314,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create()
         proforma.issue()
         proforma.cancel()
-        proforma.save()
 
         url = reverse('proforma-entry-create', kwargs={'document_pk': proforma.pk})
         entry_data = {
@@ -339,7 +337,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create()
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         url = reverse('proforma-entry-create', kwargs={'document_pk': proforma.pk})
         entry_data = {
@@ -362,7 +359,6 @@ class TestProformaEndpoints(APITestCase):
     def test_edit_proforma_in_issued_state(self):
         proforma = ProformaFactory.create()
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-detail', kwargs={'pk': proforma.pk})
         data = {"description": "New Page views"}
@@ -377,7 +373,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create()
         proforma.issue()
         proforma.cancel()
-        proforma.save()
 
         url = reverse('proforma-detail', kwargs={'pk': proforma.pk})
         data = {"description": "New Page views"}
@@ -392,7 +387,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create()
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         url = reverse('proforma-detail', kwargs={'pk': proforma.pk})
         data = {"description": "New Page views"}
@@ -485,7 +479,6 @@ class TestProformaEndpoints(APITestCase):
         customer = CustomerFactory.create()
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'issued'}
@@ -500,7 +493,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'issued'}
@@ -514,7 +506,6 @@ class TestProformaEndpoints(APITestCase):
         customer = CustomerFactory.create()
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'paid'}
@@ -545,7 +536,6 @@ class TestProformaEndpoints(APITestCase):
         customer = CustomerFactory.create()
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {
@@ -592,7 +582,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'paid'}
@@ -606,7 +595,6 @@ class TestProformaEndpoints(APITestCase):
         customer = CustomerFactory.create()
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'canceled'}
@@ -630,7 +618,6 @@ class TestProformaEndpoints(APITestCase):
         customer = CustomerFactory.create()
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {
@@ -675,7 +662,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
         proforma.cancel()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'canceled'}
@@ -694,7 +680,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'canceled'}
@@ -725,7 +710,6 @@ class TestProformaEndpoints(APITestCase):
         customer = CustomerFactory.create()
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'illegal-state'}
@@ -742,7 +726,6 @@ class TestProformaEndpoints(APITestCase):
         proforma = ProformaFactory.create(provider=provider, customer=customer)
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         url = reverse('proforma-state', kwargs={'pk': proforma.pk})
         data = {'state': 'illegal-state'}

--- a/silver/tests/spec/test_transactions.py
+++ b/silver/tests/spec/test_transactions.py
@@ -91,7 +91,7 @@ class TestTransactionEndpoint(APITestCase):
         entry = DocumentEntryFactory(quantity=1, unit_price=200)
         proforma = ProformaFactory.create(customer=customer,
                                           proforma_entries=[entry])
-        proforma.state = proforma.STATES.ISSUED
+        proforma.issue()
         proforma.create_invoice()
         proforma.refresh_from_db()
         invoice = proforma.invoice
@@ -194,11 +194,9 @@ class TestTransactionEndpoint(APITestCase):
 
         invoice = InvoiceFactory.create(customer=customer)
         invoice.issue()
-        invoice.save()
 
         proforma = ProformaFactory.create(customer=customer)
         proforma.issue()
-        proforma.save()
 
         valid_until = datetime.now().replace(microsecond=0)
         url = reverse('payment-method-transaction-list',
@@ -230,7 +228,7 @@ class TestTransactionEndpoint(APITestCase):
         payment_method = PaymentMethodFactory.create(customer=customer)
 
         proforma = ProformaFactory.create()
-        proforma.state = proforma.STATES.ISSUED
+        proforma.issue()
         proforma.create_invoice()
         proforma.refresh_from_db()
         invoice = proforma.invoice

--- a/silver/tests/tasks/test_generate_pdfs.py
+++ b/silver/tests/tasks/test_generate_pdfs.py
@@ -1,0 +1,71 @@
+import pytest
+from mock import patch, call, MagicMock
+
+from silver.tasks import generate_pdfs, generate_pdf
+from silver.tests.factories import InvoiceFactory, ProformaFactory
+
+
+@pytest.mark.django_db
+def test_generate_pdfs_task():
+    issued_invoice = InvoiceFactory.create()
+    issued_invoice.issue()
+
+    paid_invoice = InvoiceFactory.create()
+    paid_invoice.issue()
+    paid_invoice.pay()
+
+    canceled_invoice = InvoiceFactory.create()
+    canceled_invoice.issue()
+    canceled_invoice.cancel()
+
+    issued_invoice_already_generated = InvoiceFactory.create()
+    issued_invoice_already_generated.issue()
+    issued_invoice_already_generated.pdf.dirty = False
+    issued_invoice_already_generated.pdf.save()
+
+    issued_proforma = ProformaFactory.create()
+    issued_proforma.issue()
+
+    issued_proforma_already_generated = ProformaFactory.create()
+    issued_proforma_already_generated.issue()
+    issued_proforma_already_generated.pdf.dirty = False
+    issued_proforma_already_generated.pdf.save()
+
+    documents_to_generate = [issued_invoice, canceled_invoice, paid_invoice,
+                             issued_proforma]
+
+    for document in documents_to_generate:
+        assert document.pdf.dirty
+
+    with patch('silver.tasks.generate_pdf') as generate_pdf_mock:
+        generate_pdfs()
+
+        generate_pdf_mock.assert_has_calls([call.delay(document.id, document.kind)
+                                            for document in documents_to_generate],
+                                           any_order=True)
+
+
+@pytest.mark.django_db
+def test_generate_pdf_task(settings, tmpdir, monkeypatch):
+    settings.MEDIA_ROOT = tmpdir.strpath
+
+    invoice = InvoiceFactory.create()
+    invoice.issue()
+
+    assert invoice.pdf.dirty
+
+    generate_pdf_mock = MagicMock()
+
+    monkeypatch.setattr('silver.models.documents.pdf.generate_pdf_template_object',
+                        generate_pdf_mock)
+    generate_pdf(invoice.id, invoice.kind)
+
+    # pdf needs to be refreshed as the invoice reference in the test is not the same with the one
+    # in the task
+    invoice.pdf.refresh_from_db()
+
+    assert not invoice.pdf.dirty
+
+    assert invoice.pdf.url == settings.MEDIA_URL + invoice.get_pdf_upload_path()
+
+    assert generate_pdf_mock.call_count == 1

--- a/silver/tests/unit/test_proforma.py
+++ b/silver/tests/unit/test_proforma.py
@@ -29,7 +29,6 @@ class TestProforma(TestCase):
         proforma.create_invoice()
 
         proforma.pay()
-        proforma.save()
 
         assert proforma.invoice.state == Invoice.STATES.PAID
         assert proforma.state == Invoice.STATES.PAID
@@ -38,7 +37,6 @@ class TestProforma(TestCase):
         proforma = ProformaFactory.create()
         proforma.issue()
         proforma.pay()
-        proforma.save()
 
         entries = DocumentEntryFactory.create_batch(3)
         proforma.proforma_entries.add(*entries)
@@ -86,7 +84,6 @@ class TestProforma(TestCase):
             proforma.create_invoice()
 
         proforma.cancel()
-        proforma.save()
 
         assert proforma.state == proforma.invoice.state == Proforma.STATES.CANCELED
 

--- a/silver/vendors/celery_app.py
+++ b/silver/vendors/celery_app.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+import os
+
+from celery import Celery
+from django.conf import settings
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+
+app = Celery('silver')
+app.config_from_object(settings, namespace='CELERY')
+
+app.autodiscover_tasks()
+
+task = app.task

--- a/silver/vendors/redis_server.py
+++ b/silver/vendors/redis_server.py
@@ -1,0 +1,6 @@
+from redlock import Redlock
+
+from django.conf import settings
+
+
+lock_manager = Redlock([settings.LOCK_MANAGER_CONNECTION,])

--- a/silver/vendors/redis_server.py
+++ b/silver/vendors/redis_server.py
@@ -3,4 +3,4 @@ from redlock import Redlock
 from django.conf import settings
 
 
-lock_manager = Redlock([settings.LOCK_MANAGER_CONNECTION,])
+lock_manager = Redlock([settings.LOCK_MANAGER_CONNECTION])

--- a/silver/vendors/redis_server.py
+++ b/silver/vendors/redis_server.py
@@ -1,6 +1,7 @@
-from redlock import Redlock
+from redis import StrictRedis
 
 from django.conf import settings
 
-
-lock_manager = Redlock([settings.LOCK_MANAGER_CONNECTION])
+redis = StrictRedis.from_url(
+    getattr(settings, 'CONFIG_SERVER', 'redis://127.0.0.1:6379')
+)


### PR DESCRIPTION
* Added a `PDF` model
* Document `pdf` field is no longer a `FileField` but a `ForeignKey` to the `PDF` model
* Document's are automatically saved after every transition for more consistency
* PDF's are now generated and uploaded asynchronously through a non-overlapping celery beat task
* Made sure the migrations apply properly (forwards and backwards)