### PR TITLE
Removing admin site from urls.py

### DIFF
--- a/silver/urls.py
+++ b/silver/urls.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import
 
 from django.conf.urls import include, url
-from django.contrib import admin
 
 from silver.views import (pay_transaction_view, complete_payment_view,
                           InvoiceAutocomplete, ProformaAutocomplete,
@@ -26,11 +25,7 @@ from silver.views import (pay_transaction_view, complete_payment_view,
                           CustomerAutocomplete, ProviderAutocomplete)
 
 
-admin.autodiscover()
-
-
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(r'', include('silver.api.urls')),


### PR DESCRIPTION
I'm removing this as I *believe* the admin URLs should really be added by the host
django project. Adding the urls in the host project *and* in silver triggers the
following django warning:

    ?: (urls.W005) URL namespace 'admin' isn't unique. You may not be able to reverse all URLs in this namespace

I therefore propose it's removal

---

Note I haven't been able to run the tests for this change I applied it to the current master stripe code, rather than applying it on top of the changes in #677